### PR TITLE
Android エラー一覧を更新

### DIFF
--- a/Android/Android Studio/Error/一覧.md
+++ b/Android/Android Studio/Error/一覧.md
@@ -155,6 +155,8 @@ Manifest merger failed : Apps targeting Android 12 and higher are required to sp
 >
 >Rebuild targeting Android 12 and if it works, then you found the bug!
 
+- [Android 12 - IntentFilterのexportedの明示的な宣言](https://codechacha.com/ko/android-12-intent-filter-explicit-exported/)
+
 つまり、以下の操作をする必要がある。
 
 - `AndroidManifest.xml`の`<activity>`に`android:exprted="true"`を追加。


### PR DESCRIPTION
以下のエラーについて追記。
```
Manifest merger failed : Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```